### PR TITLE
allow for nested field-value pairs in batched endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ express-batch
 
 ## Description
 
-Handler for [Express 4](http://expressjs.com/4x/api.html) application that allows to perform batch requests.
+Middleware for [Express 4.x](http://expressjs.com/4x/api.html) that allows for batched API requests.
 
 It's attached as a handler for a particular route.
 
@@ -27,11 +27,11 @@ var express = require("express");
 var expressBatch = require("express-batch");
 var app = express();
 
-// mounting batch handler
+// mount batch middeleware
 app.use("/api/batch", expressBatch(app));
 
 
-// mounting ordinary API endpoints
+// mount ordinary API endpoints
 app.get("/api/constants/pi", function apiUserHandler(req, res) {
     res.send(Math.PI);
 });
@@ -43,7 +43,7 @@ app.get("/api/users/:id", function apiUserHandler(req, res) {
     });
 });
 
-// starting app
+// start the app
 app.listen(3000);
 ```
 [This example in code.](example)
@@ -70,6 +70,28 @@ With this example, a request to  `http://localhost:3000/api/batch?users=/api/use
 }
 ```
 
+It is also possible to have nested field-value pairs by passing in an options argument with a custom separator property.
+
+// mount batch handler with optional separator for nested field-value pairs
+var options = {
+    separator: ';'
+};
+app.use("/api/batch", expressBatch(app, options));
+
+// easily handle batched requests with deep field-value pairs
+app.get("/api/climate/", function apiClimateHandler(req, res) {
+    var response = {
+        sunny: false,
+        warm: false
+    };
+
+    // e.g., with a request path of 'api/batch?climate=/api/climate/?sunny=true&warm=true'
+    if (req.query.sunny === 'true' && req.query.warm === 'true') {
+        response.sunny = true;
+        response.warm = true;
+    }
+    res.json(response);
+});
 
 ## Limitations
 * Tested only with Express 4

--- a/README.md
+++ b/README.md
@@ -9,15 +9,15 @@ express-batch
 
 ## Description
 
-Handler for [Express 4](http://expressjs.com/4x/api.html) application, which allows to perform batch requests.
+Handler for [Express 4](http://expressjs.com/4x/api.html) application that allows to perform batch requests.
 
-It's attached as handler of an particular route.
+It's attached as a handler for a particular route.
 
-If you need to perform several different requests to one API simultaneously, you could combine them all together (in one querystring) and send only one request to the handler's route;  
+If you need to perform several different requests to one API simultaneously, you could combine them all together (in one querystring) and send only one request to the handler's route.
 
-Handler parses requests, tries to invoke relevant handler for each request (standard app router is used), collect all responses and send them back as JSON object with sections for each response.
+The handler parses requests, and then invokes the relevant handler for each request (the standard app router is used), collects all the responses and sends them back as a JSON object with sections for each response.
 
-Currently only routes for GET locations supported.
+Currently, only routes for GET locations are upported.
 
 ## Example
 
@@ -48,7 +48,7 @@ app.listen(3000);
 ```
 [This example in code.](example)
 
-With this example request to  `http://localhost:3000/api/batch?users=/api/users/49&pi=api/constants/pi&nonexistent=/not/existent/route` will return:
+With this example, a request to  `http://localhost:3000/api/batch?users=/api/users/49&pi=api/constants/pi&nonexistent=/not/existent/route` will return:
 
 ```js
 {
@@ -87,7 +87,7 @@ With this example request to  `http://localhost:3000/api/batch?users=/api/users/
     
 ## Notes
 
- There are similar packages, but which work via using real http requests:
+There are similar packages, but which work using real http requests:
 - [sonofabatch](https://www.npmjs.org/package/sonofabatch)   
 - [batch-endpoint](https://www.npmjs.org/package/batch-endpoint)
 - [express-batch-proxy](https://github.com/codastic/express-batch-proxy)

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ With this example, a request to  `http://localhost:3000/api/batch?users=/api/use
 
 It is also possible to have nested field-value pairs by passing in an options argument with a custom separator property.
 
+```js
 // mount batch handler with optional separator for nested field-value pairs
 var options = {
     separator: ';'
@@ -92,6 +93,7 @@ app.get("/api/climate/", function apiClimateHandler(req, res) {
     }
     res.json(response);
 });
+```
 
 ## Limitations
 * Tested only with Express 4

--- a/index.js
+++ b/index.js
@@ -1,13 +1,35 @@
 "use strict";
 
+var url = require('url');
+
 var FakeRequest = require('./lib/FakeRequest');
 var FakeResponse = require('./lib/FakeResponse');
 
 module.exports = function expressBatch(app, options) {
 
+    options = options || {};
+
     return function (req, res) {
         var results = {};
-        var requests = req.query;
+        var requests = {};
+
+        // Attempt to parse the req.url object
+        var query = url.parse(req.url).query;
+
+        // If the separator option exists and the request URL can be parsed, parse any nested field-value pairs
+        if (options.separator && query) {
+            query = decodeURIComponent(query);
+            var quriesWithPairs = query.split(options.separator);
+            quriesWithPairs.forEach(function(query, i) {
+                requests[query.substring(0,query.indexOf('='))] = query.substring(query.indexOf('=')+1);
+            });
+        }
+
+        // Otherwise, use the req.query object as-is
+        else {
+            requests = req.query;
+        }
+
         var requestCount = Object.keys(requests).length;
         var finishedRequests = 0;
 

--- a/test/express-batch.js
+++ b/test/express-batch.js
@@ -344,7 +344,7 @@ describe("request to route for express-batch", function () {
 
         beforeEach(function () {
             var options = {
-                separator: '|'
+                separator: ';'
             };
             app.use("/api/batchNested", expressBatch(app, options));
         });
@@ -376,7 +376,7 @@ describe("request to route for express-batch", function () {
                 });
 
             request(app)
-                .get("/api/batchNested?climate=/api/climate/?sunny=true&warm=true|topography=/api/topography/?hilly=false&rocky=false")
+                .get("/api/batchNested?climate=/api/climate/?sunny=true&warm=true;topography=/api/topography/?hilly=false&rocky=false")
                 .expect({
                     climate: {
                         status: 200,

--- a/test/express-batch.js
+++ b/test/express-batch.js
@@ -340,6 +340,63 @@ describe("request to route for express-batch", function () {
         });
     });
 
+    describe("with two endpoints specified, with a nested series of field-value pairs using an optional separator", function () {
+
+        beforeEach(function () {
+            var options = {
+                separator: '|'
+            };
+            app.use("/api/batchNested", expressBatch(app, options));
+        });
+
+        it("should return results for two endpoints with nested field-value pairs", function (done) {
+
+            app
+                .get("/api/climate/", function apiClimateHandler(req, res) {
+                    var response = {
+                        sunny: false,
+                        warm: false
+                    };
+                    if (req.query.sunny === 'true' && req.query.warm === 'true') {
+                        response.sunny = true;
+                        response.warm = true;
+                    }
+                    res.json(response);
+                })
+                .get("/api/topography/", function apiTopographyHandler(req, res) {
+                    var response = {
+                        hilly: true,
+                        rocky: true
+                    };
+                    if (req.query.hilly === 'false' && req.query.rocky === 'false') {
+                        response.hilly = false;
+                        response.rocky = false;
+                    }
+                    res.json(response);
+                });
+
+            request(app)
+                .get("/api/batchNested?climate=/api/climate/?sunny=true&warm=true|topography=/api/topography/?hilly=false&rocky=false")
+                .expect({
+                    climate: {
+                        status: 200,
+                        result: {
+                            sunny: true,
+                            warm: true
+                        }
+                    },
+                    topography: {
+                        status: 200,
+                        result: {
+                            hilly: false,
+                            rocky: false
+                        }
+                    }
+                })
+                .expect(200, done);
+        });
+    });
+
     describe("with activated headers passing", function () {
 
         beforeEach(function () {


### PR DESCRIPTION
Hi @yarikos-- first of all, thanks for creating this very handy module!

One issue that I ran into while using it was the inability to have "nested" field-value pairs in my query strings. I say "nested" because this module (and many like it) already leverage `req.query` to separate the distinct batched API endpoints via field-value pairs. However, if any of those batched API endpoints require field-value pairs, it no longer works. This slight change (test included) allows for you to pass in an optional "separator" value (in this test, `|` is used), to indicate that the endpoints should not be separated by `&`, and that `&` should rather be considered an integral part of the endpoint's query string. In other words, whereas before `/api/batch?one=/api/test?option1=true&option2=false&two=/api/test` would be represented in the `requests` object as something like

```js
{
  one: '/api/test?option1=true',
  option2: 'false',
  two: '/api/test'
}
```

it is now possible, by initializing the middleware with an optional parameter (e.g., `app.use('/api/batchNested', expressBatch(app, { separator: '|' }))`), and changing the batch endpoint query string accordingly to `/api/batch?one=/api/test?option1=true&option2=false|two=/api/test`, it will now be represented as:

```js
{
  one: '/api/test?option1=true&option2=false',
  two: '/api/test'
}
```

as it might be desired.

Does that make sense?

If so, please feel free to merge this PR. Thanks!